### PR TITLE
Update CmsPageStorageWriter.php

### DIFF
--- a/src/Spryker/Zed/CmsStorage/Business/Storage/CmsPageStorageWriter.php
+++ b/src/Spryker/Zed/CmsStorage/Business/Storage/CmsPageStorageWriter.php
@@ -316,10 +316,9 @@ class CmsPageStorageWriter implements CmsPageStorageWriterInterface
         $idCmsPage = $cmsPageEntity->getIdCmsPage();
         $cmsPageStores = $cmsPageEntity->getSpyCmsPageStores();
 
-        foreach ($localeNames as $localeName) {
-            foreach ($cmsPageStores as $cmsPageStore) {
-                $storeName = $cmsPageStore->getSpyStore()->getName();
-
+        foreach ($cmsPageStores as $cmsPageStore) {
+            $storeName = $cmsPageStore->getSpyStore()->getName();
+            foreach (Store::getInstance()->getLocalesPerStore($storeName) as $localeName) {
                 $cmsPageStorageEntity = isset($cmsPageStorageEntities[$idCmsPage][$localeName][$storeName]) ?
                     $cmsPageStorageEntities[$idCmsPage][$localeName][$storeName] :
                     new SpyCmsPageStorage();


### PR DESCRIPTION
Suppose you have two stores. 
DE with de as language and US with en as language.
When you save the CMS page from US backend than you generate US:de and US:en and remove the DE:de cms page. 

So don't use the localeNames parameter and get it from the store config instead.